### PR TITLE
Set libcephfs version via maven property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,10 @@
 	<url>https://oss.sonatype.org/content/repositories/snapshots</url>
       </snapshotRepository>
     </distributionManagement>
+    
+    <properties>
+    	<libcephfs.version>0.80.5</libcephfs.version>
+    </properties>
 
     <dependencies>
       <dependency>
@@ -88,7 +92,7 @@
       <dependency>
         <groupId>com.ceph</groupId>
         <artifactId>libcephfs</artifactId>
-        <version>0.80.5</version>
+        <version>${libcephfs.version}</version>
       </dependency>
     </dependencies>
 


### PR DESCRIPTION
This change moves the libcephfs artifact version into a maven property. The default value is still `0.80.5` as before, but now if one wishes to build cephfs-hadoop with a different version of libcephfs.jar it can be done without modifying `pom.xml`