### PR TITLE
Set hadoop version via maven property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     </distributionManagement>
     
     <properties>
+    	<hadoop.version>2.4.0</hadoop.version>
     	<libcephfs.version>0.80.5</libcephfs.version>
     </properties>
 
@@ -86,7 +87,7 @@
       <dependency>
 	<groupId>org.apache.hadoop</groupId>
 	<artifactId>hadoop-common</artifactId>
-	<version>2.4.0</version>
+	<version>${hadoop.version}</version>
       </dependency>
     
       <dependency>


### PR DESCRIPTION
This change moves the hadoop artifact version into a maven property. The default value is still2.4.0 as before, but now if one wishes to build cephfs-hadoop with a different version of hadoop it can be done without modifying pom.xml