### PR TITLE
Code quality fix - Array designators "[]" should be on the type, not the variable.

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/ceph/CephInputStream.java
+++ b/src/main/java/org/apache/hadoop/fs/ceph/CephInputStream.java
@@ -157,7 +157,7 @@ public class CephInputStream extends FSInputStream {
         "CephInputStream.read: Reading a single byte from fd " + fileHandle
         + " by calling general read function");
 
-    byte result[] = new byte[1];
+    byte[] result = new byte[1];
 
     if (getPos() >= fileLength) {
       return -1;
@@ -181,7 +181,7 @@ public class CephInputStream extends FSInputStream {
    * @throws IOException on bad input.
    */
   @Override
-  public synchronized int read(byte buf[], int off, int len)
+  public synchronized int read(byte[] buf, int off, int len)
     throws IOException {
     LOG.trace(
         "CephInputStream.read: Reading " + len + " bytes from fd " + fileHandle);

--- a/src/main/java/org/apache/hadoop/fs/ceph/CephOutputStream.java
+++ b/src/main/java/org/apache/hadoop/fs/ceph/CephOutputStream.java
@@ -99,13 +99,13 @@ public class CephOutputStream extends OutputStream {
 
   @Override
   public synchronized void write(int b) throws IOException {
-    byte buf[] = new byte[1];
+    byte[] buf = new byte[1];
     buf[0] = (byte) b;    
     write(buf, 0, 1);
   }
 
   @Override
-  public synchronized void write(byte buf[], int off, int len) throws IOException {
+  public synchronized void write(byte[] buf, int off, int len) throws IOException {
     checkOpen();
 
     while (len > 0) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.

Faisal Hameed