### PR TITLE
Multiple code quality fix-1

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/ceph/CephConfigKeys.java
+++ b/src/main/java/org/apache/hadoop/fs/ceph/CephConfigKeys.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.fs.CommonConfigurationKeys;
  */
 public class CephConfigKeys extends CommonConfigurationKeys {
   public static final String CEPH_OBJECT_SIZE_KEY = "ceph.object.size";
-  public static final long   CEPH_OBJECT_SIZE_DEFAULT = 64*1024*1024;
+  public static final long   CEPH_OBJECT_SIZE_DEFAULT = 64*1024*1024L;
 
   public static final String CEPH_CONF_FILE_KEY = "ceph.conf.file";
   public static final String CEPH_CONF_FILE_DEFAULT = null;

--- a/src/main/java/org/apache/hadoop/fs/ceph/CephFileSystem.java
+++ b/src/main/java/org/apache/hadoop/fs/ceph/CephFileSystem.java
@@ -401,9 +401,8 @@ public class CephFileSystem extends FileSystem {
         throw new FileAlreadyExistsException();
     } else {
       Path parent = path.getParent();
-      if (parent != null)
-        if (!mkdirs(parent))
-          throw new IOException("mkdirs failed for " + parent.toString());
+      if (parent != null && !mkdirs(parent))
+    	  throw new IOException("mkdirs failed for " + parent.toString());
     }
 
     if (progress != null) {

--- a/src/main/java/org/apache/hadoop/fs/ceph/CephInputStream.java
+++ b/src/main/java/org/apache/hadoop/fs/ceph/CephInputStream.java
@@ -97,7 +97,7 @@ public class CephInputStream extends FSInputStream {
       throw new IOException("Failed to fill read buffer! Error code:" + err);
     }
     cephPos += bufValid;
-    return (bufValid != 0);
+    return bufValid != 0;
   }
 
   /*

--- a/src/main/java/org/apache/hadoop/fs/ceph/CephOutputStream.java
+++ b/src/main/java/org/apache/hadoop/fs/ceph/CephOutputStream.java
@@ -138,8 +138,8 @@ public class CephOutputStream extends OutputStream {
         return;
       }
 
-      assert(ret > 0);
-      assert(ret < bufUsed);
+      assert ret > 0;
+      assert ret < bufUsed;
 
       /*
        * TODO: handle a partial write by shifting the remainder of the data in
@@ -153,7 +153,7 @@ public class CephOutputStream extends OutputStream {
       bufUsed -= ret;
     }
 
-    assert(bufUsed == 0);
+    assert bufUsed == 0;
   }
    
   @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1066 - Collapsible "if" statements should be merged. 
squid:S2184 - Math operands should be cast before assignment.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S2184

Please let me know if you have any questions.

Faisal Hameed