### PR TITLE
Fix the "INVALID ARGUMENT" issue when we mount java client on sub dir

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/ceph/CephFileSystem.java
+++ b/src/main/java/org/apache/hadoop/fs/ceph/CephFileSystem.java
@@ -320,9 +320,7 @@ public class CephFileSystem extends FileSystem {
      * something bad, so we throw any exceptions. For configured pools we
      * ignore some errors.
      */
-    int fd = ceph.__open(new Path("/"), CephMount.O_RDONLY, 0);
-    String pool_name = ceph.get_file_pool_name(fd);
-    ceph.close(fd);
+    String pool_name = ceph.get_default_data_pool_name();
     int replication = getPoolReplication(pool_name);
     pools.put(new Integer(replication), pool_name);
 

--- a/src/main/java/org/apache/hadoop/fs/ceph/CephFsProto.java
+++ b/src/main/java/org/apache/hadoop/fs/ceph/CephFsProto.java
@@ -61,6 +61,7 @@ abstract class CephFsProto {
   abstract void mkdirs(Path path, int mode) throws IOException;
   abstract int get_stripe_unit_granularity();
   abstract String get_file_pool_name(int fd);
+  abstract String get_default_data_pool_name();
   abstract int get_pool_id(String pool_name) throws IOException;;
   abstract int get_pool_replication(int poolid) throws IOException;
   abstract InetAddress get_osd_address(int osd) throws IOException;

--- a/src/main/java/org/apache/hadoop/fs/ceph/CephTalker.java
+++ b/src/main/java/org/apache/hadoop/fs/ceph/CephTalker.java
@@ -316,6 +316,10 @@ class CephTalker extends CephFsProto {
     return mount.get_file_pool_name(fd);
   }
 
+  String get_default_data_pool_name() {
+    return mount.get_default_data_pool_name();
+  }
+
   int get_pool_id(String pool_name) throws IOException {
     try {
       return mount.get_pool_id(pool_name);


### PR DESCRIPTION
correct the way to choose a default cephfs data pool

Signed-off-by: dongdong tao <tdd21151186@gmail.com>