### PR TITLE
FileNotFoundException should be thrown if path doesn't exist in listS…

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/ceph/CephFileSystem.java
+++ b/src/main/java/org/apache/hadoop/fs/ceph/CephFileSystem.java
@@ -253,7 +253,7 @@ public class CephFileSystem extends FileSystem {
     if (isFile(path))
       return new FileStatus[] { getFileStatus(path) };
 
-    return null;
+    throw new FileNotFoundException("File " + path + " does not exist.");
   }
 
   @Override


### PR DESCRIPTION
…tatus()

Signed-off-by: Zhu Shangzhong <zhu.shangzhong@zte.com.cn>