### PR TITLE
isDir should be replaced with isFile in delete method

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/ceph/CephFileSystem.java
+++ b/src/main/java/org/apache/hadoop/fs/ceph/CephFileSystem.java
@@ -614,7 +614,7 @@ public class CephFileSystem extends FileSystem {
     }
 
     /* we're done if its a file */
-    if (!status.isDir()) {
+    if (status.isFile()) {
       ceph.unlink(path);
       return true;
     }


### PR DESCRIPTION
The isDir method has been deprecated in Hadoop.

Signed-off-by: Zhu Shangzhong <zhu.shangzhong@zte.com.cn>