### PR TITLE
fs: Add CephRgwFileSystem base on librgw for hadoop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,13 @@
 	<scope>system</scope>
 	<systemPath>${project.basedir}/src/test/resources/hadoop-common-3.0.0-SNAPSHOT.jar</systemPath>
       </dependency>      
+      <dependency>
+       	<groupId>com.ceph</groupId>
+        <artifactId>cephrgw</artifactId>
+        <version>1.0</version>
+	<scope>system</scope>
+	<systemPath>/usr/share/java/libcephrgw.jar</systemPath>
+      </dependency>      
       
       
       <dependency>

--- a/src/main/java/org/apache/hadoop/fs/cephrgw/CephConfigKeys.java
+++ b/src/main/java/org/apache/hadoop/fs/cephrgw/CephConfigKeys.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.cephrgw;
+
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+
+
+/**
+ * Configuration key constants used by CephRgwFileSystem.
+ */
+public class CephConfigKeys extends CommonConfigurationKeys {
+    public static final String CEPH_RGW_ARGS_KEY = "fs.ceph.rgw.args";
+    public static final String CEPH_RGW_ARGS_DEFAULT = "--name=client.admin";
+
+    public static final String CEPH_RGW_BLOCKSIZE_KEY = "fs.ceph.rgw.blocksize";
+    public static final long CEPH_RGW_BLOCKSIZE_DEFAULT = 64 * 1024 * 1024;
+
+    public static final String CEPH_REPLICATION_KEY = "fs.ceph.replication";
+    public static final short CEPH_REPLICATION_DEFAULT = 3;
+
+    public static final String CEPH_RGW_USERID_KEY = "fs.ceph.rgw.userid";
+    public static final String CEPH_RGW_USERID_DEFAULT = null;
+
+    public static final String CEPH_RGW_ACCESS_KEY_KEY = "fs.ceph.rgw.access.key";
+    public static final String CEPH_RGW_ACCESS_KEY_DEFAULT = null;
+
+    public static final String CEPH_RGW_SECRET_KEY_KEY = "fs.ceph.rgw.secret.key";
+    public static final String CEPH_RGW_SECRET_KEY_DEFAULT = null;
+}

--- a/src/main/java/org/apache/hadoop/fs/cephrgw/CephFsProto.java
+++ b/src/main/java/org/apache/hadoop/fs/cephrgw/CephFsProto.java
@@ -1,0 +1,67 @@
+// -*- mode:Java; tab-width:2; c-basic-offset:2; indent-tabs-mode:t -*- 
+
+/**
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ * <p>
+ * <p>
+ * Abstract base class for communicating with a Ceph filesystem and its
+ * C++ codebase from Java, or pretending to do so (for unit testing purposes).
+ * As only the Ceph package should be using this directly, all methods
+ * are protected.
+ */
+package org.apache.hadoop.fs.cephrgw;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.InetAddress;
+import java.util.LinkedList;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.conf.Configuration;
+
+import com.ceph.rgw.CephStat;
+import com.ceph.rgw.CephStatVFS;
+
+abstract class CephFsProto {
+    abstract void initialize(URI uri, Configuration conf) throws IOException;
+
+    abstract long __open(Path path, int flags, int mode) throws IOException;
+
+    abstract long open(Path path, int flags, int mode) throws IOException;
+
+    abstract void lstat(Path path, CephStat stat) throws IOException;
+
+    abstract void statfs(Path path, CephStatVFS stat) throws IOException;
+
+    abstract void unlink(Path path) throws IOException;
+
+    abstract int listdir(Path path, LinkedList<String> names, LinkedList<CephStat> stats) throws IOException;
+
+    abstract void setattr(Path path, CephStat stat, int mask) throws IOException;
+
+    abstract void close(long fd) throws IOException;
+
+    abstract void shutdown() throws IOException;
+
+    abstract boolean rename(Path src, Path dst) throws IOException;
+
+    abstract short getDefaultReplication();
+
+    abstract int write(long fd, long offset, byte[] buf, long size) throws IOException;
+
+    abstract int read(long fd, long offset, byte[]buf, long size) throws IOException;
+
+    abstract boolean mkdirs(Path path, int mode) throws IOException;
+
+    abstract void fsync(long fd) throws IOException;
+}

--- a/src/main/java/org/apache/hadoop/fs/cephrgw/CephInputStream.java
+++ b/src/main/java/org/apache/hadoop/fs/cephrgw/CephInputStream.java
@@ -1,0 +1,250 @@
+// -*- mode:Java; tab-width:2; c-basic-offset:2; indent-tabs-mode:t -*- 
+
+/**
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ * <p>
+ * <p>
+ * Implements the Hadoop FS interfaces to allow applications to store
+ * files in Ceph.
+ */
+package org.apache.hadoop.fs.cephrgw;
+
+
+import java.io.IOException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSInputStream;
+
+import com.ceph.rgw.CephRgwAdapter;
+
+/**
+ * <p>
+ * An {@link FSInputStream} for a CephRgwFileSystem and corresponding
+ * Ceph instance.
+ */
+public class CephInputStream extends FSInputStream {
+    private static final Log LOG = LogFactory.getLog(CephInputStream.class);
+    private boolean closed;
+
+    private long fileHandle;
+    private long fileLength;
+
+    private CephFsProto ceph;
+
+    private byte[] buffer;
+    private int bufPos = 0;
+    private int bufValid = 0;
+    private long cephPos = 0;
+
+    /**
+     * Create a new CephInputStream.
+     * @param conf The system configuration. Unused.
+     * @param cephfs CephFsProto
+     * @param fh The filehandle provided by Ceph to reference.
+     * @param flength The current length of the file. If the length changes
+     * you will need to close and re-open it to access the new data.
+     * @param bufferSize the size of the buffer to be used.
+     */
+    public CephInputStream(Configuration conf, CephFsProto cephfs,
+                           long fh, long flength, int bufferSize) {
+        // Whoever's calling the constructor is responsible for doing the actual ceph_open
+        // call and providing the file handle.
+        fileLength = flength;
+        fileHandle = fh;
+        closed = false;
+        ceph = cephfs;
+        int len = Math.min((int) flength, 1 << 22);
+        buffer = new byte[len];
+        LOG.debug(
+                "CephInputStream constructor: initializing stream with fh " + fh
+                        + " and file length " + flength);
+
+    }
+
+    /** Ceph likes things to be closed before it shuts down,
+     * so closing the IOStream stuff voluntarily in a finalizer is good
+     */
+    protected void finalize() throws Throwable {
+        try {
+            if (!closed) {
+                close();
+            }
+        } finally {
+            super.finalize();
+        }
+    }
+
+    private synchronized boolean fillBuffer() throws IOException {
+        bufValid = ceph.read(fileHandle, cephPos, buffer, buffer.length);
+        bufPos = 0;
+        if (bufValid < 0) {
+            int err = bufValid;
+
+            bufValid = 0;
+            throw new IOException("Failed to fill read buffer! Error code:" + err);
+        }
+
+        cephPos += bufValid;
+        return (bufValid != 0);
+    }
+
+    /*
+     * Get the current position of the stream.
+     */
+    public synchronized long getPos() throws IOException {
+        return cephPos - bufValid + bufPos;
+    }
+
+    /**
+     * Find the number of bytes remaining in the file.
+     */
+    @Override
+    public synchronized int available() throws IOException {
+        if (closed) {
+            throw new IOException("file is closed");
+        }
+        return (int) (fileLength - getPos());
+    }
+
+    public synchronized void seek(long targetPos) throws IOException {
+        LOG.trace(
+                "CephInputStream.seek: Seeking to position " + targetPos + " on fd "
+                        + fileHandle);
+        if (targetPos > fileLength) {
+            throw new IOException(
+                    "CephInputStream.seek: failed seek to position " + targetPos
+                            + " on fd " + fileHandle + ": Cannot seek after EOF " + fileLength);
+        }
+        long oldPos = cephPos;
+
+        cephPos = targetPos;
+        bufValid = 0;
+        bufPos = 0;
+    }
+
+    /**
+     * Failovers are handled by the Ceph code at a very low level;
+     * if there are issues that can be solved by changing sources
+     * they'll be dealt with before anybody even tries to call this method!
+     * @return false.
+     */
+    public synchronized boolean seekToNewSource(long targetPos) {
+        return false;
+    }
+
+    /**
+     * Read a byte from the file.
+     * @return the next byte.
+     */
+    @Override
+    public synchronized int read() throws IOException {
+        LOG.trace(
+                "CephInputStream.read: Reading a single byte from fd " + fileHandle
+                        + " by calling general read function");
+
+        byte result[] = new byte[1];
+
+        if (getPos() >= fileLength) {
+            return -1;
+        }
+        if (-1 == read(result, 0, 1)) {
+            return -1;
+        }
+        if (result[0] < 0) {
+            return 256 + (int) result[0];
+        } else {
+            return result[0];
+        }
+    }
+
+    /**
+     * Read a specified number of bytes from the file into a byte[].
+     * @param buf the byte array to read into.
+     * @param off the offset to start at in the file
+     * @param len the number of bytes to read
+     * @return 0 if successful, otherwise an error code.
+     * @throws IOException on bad input.
+     */
+    @Override
+    public synchronized int read(byte buf[], int off, int len)
+            throws IOException {
+        LOG.trace(
+                "CephInputStream.read: Reading " + len + " bytes from fd " + fileHandle);
+
+        if (closed) {
+            throw new IOException(
+                    "CephInputStream.read: cannot read " + len + " bytes from fd "
+                            + fileHandle + ": stream closed");
+        }
+
+        // ensure we're not past the end of the file
+        if (getPos() >= fileLength) {
+            LOG.debug(
+                    "CephInputStream.read: cannot read " + len + " bytes from fd "
+                            + fileHandle + ": current position is " + getPos()
+                            + " and file length is " + fileLength);
+
+            return -1;
+        }
+
+        len = Math.min(len, available());
+        int totalRead = 0;
+        int initialLen = len;
+        int read;
+
+        do {
+            read = Math.min(len, bufValid - bufPos);
+            try {
+                System.arraycopy(buffer, bufPos, buf, off, read);
+            } catch (IndexOutOfBoundsException ie) {
+                throw new IOException(
+                        "CephInputStream.read: Indices out of bounds:" + "read length is "
+                                + len + ", buffer offset is " + off + ", and buffer size is "
+                                + buf.length);
+            } catch (ArrayStoreException ae) {
+                throw new IOException(
+                        "Uh-oh, CephInputStream failed to do an array"
+                                + "copy due to type mismatch...");
+            } catch (NullPointerException ne) {
+                throw new IOException(
+                        "CephInputStream.read: cannot read " + len + "bytes from fd:"
+                                + fileHandle + ": buf is null");
+            }
+            bufPos += read;
+            len -= read;
+            off += read;
+            totalRead += read;
+        } while (len > 0 && fillBuffer());
+
+        LOG.trace(
+                "CephInputStream.read: Reading " + initialLen + " bytes from fd "
+                        + fileHandle + ": succeeded in reading " + totalRead + " bytes");
+        return totalRead;
+    }
+
+    /**
+     * Close the CephInputStream and release the associated filehandle.
+     */
+    @Override
+    public void close() throws IOException {
+        LOG.trace("CephOutputStream.close:enter");
+        if (!closed) {
+            ceph.close(fileHandle);
+
+            closed = true;
+            LOG.trace("CephOutputStream.close:exit");
+        }
+    }
+}

--- a/src/main/java/org/apache/hadoop/fs/cephrgw/CephOutputStream.java
+++ b/src/main/java/org/apache/hadoop/fs/cephrgw/CephOutputStream.java
@@ -1,0 +1,164 @@
+// -*- mode:Java; tab-width:2; c-basic-offset:2; indent-tabs-mode:t -*- 
+
+/**
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ * <p>
+ * <p>
+ * Implements the Hadoop FS interfaces to allow applications to store
+ * files in Ceph.
+ */
+
+package org.apache.hadoop.fs.cephrgw;
+
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.util.Progressable;
+
+import com.ceph.rgw.CephRgwAdapter;
+
+/**
+ * <p>
+ * An {@link OutputStream} for a CephRgwFileSystem and corresponding
+ * Ceph instance.
+ * <p>
+ * TODO:
+ * - When libcephfs-jni supports ByteBuffer interface we can get rid of the
+ * use of the buffer here to reduce memory copies and just use buffers in
+ * libcephfs. Currently it might be useful to reduce JNI crossings, but not
+ * much more.
+ */
+public class CephOutputStream extends OutputStream {
+    private static final Log LOG = LogFactory.getLog(CephOutputStream.class);
+    private boolean closed;
+
+    private CephFsProto ceph;
+
+    private long fileHandle;
+
+    private byte[] buffer;
+    private int bufUsed = 0;
+    private long cephPos = 0;
+
+    public CephOutputStream(Configuration conf, CephFsProto cephfs,
+                            long fh, int bufferSize) {
+        ceph = cephfs;
+        fileHandle = fh;
+        closed = false;
+        buffer = new byte[1 << 22];
+    }
+
+    /**
+     * Close the Ceph file handle if close() wasn't explicitly called.
+     */
+    protected void finalize() throws Throwable {
+        try {
+            if (!closed) {
+                close();
+            }
+        } finally {
+            super.finalize();
+        }
+    }
+
+    /**
+     * Ensure that the stream is opened.
+     */
+    private synchronized void checkOpen() throws IOException {
+        if (closed)
+            throw new IOException("operation on closed stream (fd=" + fileHandle + ")");
+    }
+
+    public synchronized long getPos() throws IOException {
+        checkOpen();
+        return cephPos + bufUsed;
+    }
+
+    @Override
+    public synchronized void write(int b) throws IOException {
+        byte buf[] = new byte[1];
+        buf[0] = (byte) b;
+        write(buf, 0, 1);
+    }
+
+    @Override
+    public synchronized void write(byte buf[], int off, int len) throws IOException {
+        checkOpen();
+
+        while (len > 0) {
+            int remaining = Math.min(len, buffer.length - bufUsed);
+            System.arraycopy(buf, off, buffer, bufUsed, remaining);
+
+            bufUsed += remaining;
+            off += remaining;
+            len -= remaining;
+
+            if (buffer.length == bufUsed)
+                flushBuffer();
+        }
+    }
+
+    /*
+     * Moves data from the buffer into libcephfs.
+     */
+    private synchronized void flushBuffer() throws IOException {
+        if (bufUsed == 0)
+            return;
+
+        while (bufUsed > 0) {
+            int ret = ceph.write(fileHandle, cephPos, buffer, bufUsed);
+            if (ret < 0)
+                throw new IOException("ceph.write: ret=" + ret);
+            cephPos += ret;
+            if (ret == bufUsed) {
+                bufUsed = 0;
+                return;
+            }
+
+            assert (ret > 0);
+            assert (ret < bufUsed);
+
+            /*
+             * TODO: handle a partial write by shifting the remainder of the data in
+             * the buffer back to the beginning and retrying the write. It would
+             * probably be better to use a ByteBuffer 'view' here, and I believe
+             * using a ByteBuffer has some other performance benefits but we'll
+             * likely need to update the libcephfs-jni implementation.
+             */
+            int remaining = bufUsed - ret;
+            System.arraycopy(buffer, ret, buffer, 0, remaining);
+            bufUsed -= ret;
+        }
+
+        assert (bufUsed == 0);
+    }
+
+    @Override
+    public synchronized void flush() throws IOException {
+        checkOpen();
+        flushBuffer(); // buffer -> libcephfs
+        ceph.fsync(fileHandle); // libcephfs -> cluster
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        checkOpen();
+        flush();
+        ceph.close(fileHandle);
+        closed = true;
+    }
+}

--- a/src/main/java/org/apache/hadoop/fs/cephrgw/CephRgw.java
+++ b/src/main/java/org/apache/hadoop/fs/cephrgw/CephRgw.java
@@ -1,0 +1,29 @@
+package org.apache.hadoop.fs.cephrgw;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.DelegateToFileSystem;
+import org.apache.hadoop.fs.AbstractFileSystem;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * The CephRgw implementation of AbstractFileSystem.
+ * This impl delegates to the old FileSystem
+ */
+public class CephRgw extends DelegateToFileSystem {
+    /**
+     * This constructor has the signature needed by
+     * {@link AbstractFileSystem#createFileSystem(URI, Configuration)}.
+     *
+     * @param theUri which must be that of localFs
+     * @param conf
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    CephRgw(final URI theUri, final Configuration conf) throws IOException,
+            URISyntaxException {
+        super(theUri, new CephRgwFileSystem(conf), conf, "cephrgw", true);
+    }
+}

--- a/src/main/java/org/apache/hadoop/fs/cephrgw/CephRgwFileSystem.java
+++ b/src/main/java/org/apache/hadoop/fs/cephrgw/CephRgwFileSystem.java
@@ -1,0 +1,463 @@
+// -*- mode:Java; tab-width:2; c-basic-offset:2; indent-tabs-mode:t -*-
+
+/**
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ * <p>
+ * <p>
+ * Implements the Hadoop FS interfaces to allow applications to store
+ * files in Ceph.
+ */
+package org.apache.hadoop.fs.cephrgw;
+
+import java.io.IOException;
+import java.io.FileNotFoundException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.InetAddress;
+import java.util.EnumSet;
+import java.lang.Math;
+import java.util.LinkedList;
+import java.util.TreeMap;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.util.Progressable;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.net.DNS;
+import org.apache.hadoop.fs.FsStatus;
+
+import com.ceph.rgw.CephFileAlreadyExistsException;
+import com.ceph.rgw.CephRgwAdapter;
+import com.ceph.rgw.CephStat;
+import com.ceph.rgw.CephStatVFS;
+
+
+public class CephRgwFileSystem extends FileSystem {
+    private static final Log LOG = LogFactory.getLog(CephRgwFileSystem.class);
+    private URI uri;
+
+    private Path workingDir;
+    private CephFsProto ceph = null;
+
+    public CephRgwFileSystem() {
+    }
+
+    public CephRgwFileSystem(Configuration conf) {
+        setConf(conf);
+    }
+
+    /**
+     * Create an absolute path using the working directory.
+     */
+    private Path makeAbsolute(Path path) {
+        if (path.isAbsolute()) {
+            return path;
+        }
+        return new Path(workingDir, path);
+    }
+
+    public URI getUri() {
+        return uri;
+    }
+
+    @Override
+    public void initialize(URI uri, Configuration conf) throws IOException {
+        super.initialize(uri, conf);
+        if (ceph == null) {
+            ceph = new CephTalker(conf, LOG);
+        }
+        ceph.initialize(uri, conf);
+        setConf(conf);
+        try {
+            this.uri = new URI(uri.getScheme(), uri.getAuthority(), "", "");
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+        this.workingDir = getHomeDirectory();
+    }
+
+    /**
+     * Open a Ceph file and attach the file handle to an FSDataInputStream.
+     * @param path The file to open
+     * @param bufferSize Ceph does internal buffering; but you can buffer in
+     *   the Java code too if you like.
+     * @return FSDataInputStream reading from the given path.
+     * @throws IOException if the path DNE or is a
+     * directory, or there is an error getting data to set up the FSDataInputStream.
+     */
+    public FSDataInputStream open(Path path, int bufferSize) throws IOException {
+        path = makeAbsolute(path);
+
+        long fd = ceph.open(path, CephRgwAdapter.O_RDONLY, 0);
+
+        CephStat stat = new CephStat();
+        ceph.lstat(path, stat);
+
+        CephInputStream istream = new CephInputStream(getConf(), ceph, fd, stat.size, bufferSize);
+        return new FSDataInputStream(istream);
+    }
+
+    /**
+     * Close down the CephFileSystem. Runs the base-class close method
+     * and then kills the Ceph client itself.
+     */
+    @Override
+    public void close() throws IOException {
+        super.close();
+        ceph.shutdown();
+    }
+
+    public FSDataOutputStream append(Path path, int bufferSize, Progressable progress) throws IOException {
+        throw new UnsupportedOperationException("Append is not supported " + "by CephRgwFileSystem");
+    }
+
+    public Path getWorkingDirectory() {
+        return workingDir;
+    }
+
+    @Override
+    public void setWorkingDirectory(Path dir) {
+        workingDir = makeAbsolute(dir);
+    }
+
+    /**
+     * Create a directory and any nonexistent parents. Any portion
+     * of the directory tree can exist without error.
+     * @param path The directory path to create
+     * @param perms The permissions to apply to the created directories.
+     * @return true if successful, false otherwise
+     * @throws IOException if the path is a child of a file.
+     */
+    @Override
+    public boolean mkdirs(Path path, FsPermission perms) throws IOException {
+        path = makeAbsolute(path);
+
+        Path parent = path.getParent();
+        if (parent == null) {
+            return true;
+        }
+
+        if (exists(path)) {
+            if (getFileStatus(path).isFile()) {
+                throw new CephFileAlreadyExistsException(path.toString());
+            }
+            return true;
+        }
+
+        boolean ret = mkdirs(parent, perms);
+        if (!ret)
+            return ret;
+        try {
+            ret = ceph.mkdirs(path, (int) perms.toShort());
+        } catch (CephFileAlreadyExistsException e) {
+            ret = true;
+        }
+
+        return ret;
+    }
+
+    /**
+     * Create a directory and any nonexistent parents. Any portion
+     * of the directory tree can exist without error.
+     * Apply umask from conf
+     * @param f The directory path to create
+     * @return true if successful, false otherwise
+     * @throws IOException if the path is a child of a file.
+     */
+    @Override
+    public boolean mkdirs(Path f) throws IOException {
+        return mkdirs(f, FsPermission.getDirDefault().applyUMask(FsPermission.getUMask(getConf())));
+    }
+
+    /**
+     * Get stat information on a file. This does not fill owner or group, as
+     * Ceph's support for these is a bit different than HDFS'.
+     * @param path The path to stat.
+     * @return FileStatus object containing the stat information.
+     * @throws FileNotFoundException if the path could not be resolved.
+     */
+    public FileStatus getFileStatus(Path path) throws IOException {
+        path = makeAbsolute(path);
+
+        CephStat stat = new CephStat();
+        ceph.lstat(path, stat);
+
+        FileStatus status = new FileStatus(stat.size, stat.isDir(),
+                ceph.getDefaultReplication(), stat.blksize, stat.m_time,
+                stat.a_time, new FsPermission((short) stat.mode),
+                System.getProperty("user.name"), null, path.makeQualified(this));
+
+        return status;
+    }
+
+    /**
+     * Get the FileStatus for each listing in a directory.
+     * @param path The directory to get listings from.
+     * @return FileStatus[] containing one FileStatus for each directory listing;
+     *         null if path does not exist.
+     */
+    public FileStatus[] listStatus(Path path) throws IOException {
+        path = makeAbsolute(path);
+
+        LinkedList<String> names = new LinkedList<String>();
+        LinkedList<CephStat> stats = new LinkedList<CephStat>();
+        int len = ceph.listdir(path, names, stats);
+        if (len < 0)
+            throw new FileNotFoundException("File " + path + " does not exist.");
+        else if (len == 0)
+            return new FileStatus[0];
+
+        FileStatus[] status = new FileStatus[len];
+        for (int i = 0; i < len; i++) {
+            CephStat stat = stats.get(i);
+            status[i] = new FileStatus(stat.size, stat.isDir(),
+                    ceph.getDefaultReplication(), stat.blksize, stat.m_time,
+                    stat.a_time, new FsPermission((short) stat.mode),
+                    System.getProperty("user.name"), null, makeQualified(new Path(path, names.get(i))));
+        }
+        names.clear();
+        stats.clear();
+        return status;
+    }
+
+    @Override
+    public void setPermission(Path path, FsPermission permission) throws IOException {
+        path = makeAbsolute(path);
+
+        CephStat stat = new CephStat(permission.toShort());
+        ceph.setattr(path, stat, CephRgwAdapter.SETATTR_MODE);
+    }
+
+    @Override
+    public void setTimes(Path path, long mtime, long atime) throws IOException {
+        path = makeAbsolute(path);
+
+        CephStat stat = new CephStat(mtime, atime);
+        int mask = 0;
+
+        if (mtime != -1) {
+            mask |= CephRgwAdapter.SETATTR_MTIME;
+        }
+
+        if (atime != -1) {
+            mask |= CephRgwAdapter.SETATTR_ATIME;
+        }
+
+        ceph.setattr(path, stat, mask);
+    }
+
+    /**
+     * Create a new file and open an FSDataOutputStream that's connected to it.
+     * @param path The file to create.
+     * @param permission The permissions to apply to the file.
+     * @param overwrite If true, overwrite any existing file with
+           * this name; otherwise don't.
+     * @param bufferSize Ceph does internal buffering, but you can buffer
+     *   in the Java code too if you like.
+     * @param replication Replication factor. See documentation on the
+     *   "ceph.data.pools" configuration option.
+     * @param blockSize Ignored by Ceph. You can set client-wide block sizes
+     * via the fs.ceph.blockSize param if you like.
+     * @param progress A Progressable to report back to.
+     * Reporting is limited but exists.
+     * @return An FSDataOutputStream pointing to the created file.
+     * @throws IOException if the path is an
+     * existing directory, or the path exists but overwrite is false, or there is a
+     * failure in attempting to open for append with Ceph.
+     */
+    public FSDataOutputStream create(Path path, FsPermission permission,
+                                     boolean overwrite, int bufferSize, short replication, long blockSize,
+                                     Progressable progress) throws IOException {
+        path = makeAbsolute(path);
+
+        boolean exists = exists(path);
+
+        if (progress != null) {
+            progress.progress();
+        }
+
+        int flags = CephRgwAdapter.O_WRONLY | CephRgwAdapter.O_CREAT;
+
+        if (exists) {
+            if (overwrite)
+                flags |= CephRgwAdapter.O_TRUNC;
+            else
+                throw new FileAlreadyExistsException();
+        } else {
+            Path parent = path.getParent();
+            if (parent != null)
+                if (!mkdirs(parent))
+                    throw new IOException("mkdirs failed for " + parent.toString());
+        }
+
+        if (progress != null) {
+            progress.progress();
+        }
+
+        if (blockSize > Integer.MAX_VALUE) {
+            blockSize = Integer.MAX_VALUE;
+            LOG.info("blockSize too large. Rounding down to " + blockSize);
+        }
+
+        if (blockSize <= 0)
+            throw new IllegalArgumentException("Invalid block size: " + blockSize);
+
+        long fd = ceph.open(path, flags, (int) permission.toShort());
+
+        if (progress != null) {
+            progress.progress();
+        }
+
+        OutputStream ostream = new CephOutputStream(getConf(), ceph, fd, bufferSize);
+        return new FSDataOutputStream(ostream, statistics);
+    }
+
+    /**
+     * Opens an FSDataOutputStream at the indicated Path with write-progress
+     * reporting. Same as create(), except fails if parent directory doesn't
+     * already exist.
+     * @param path the file name to open
+     * @param permission The permissions to apply to the file.
+     * @param overwrite if a file with this name already exists, then if true,
+     * the file will be overwritten, and if false an error will be thrown.
+     * @param bufferSize the size of the buffer to be used.
+     * @param replication required block replication for the file.
+     * @param blockSize Ignored by Ceph. You can set client-wide block sizes
+     * via the fs.ceph.blockSize param if you like.
+     * @param progress A Progressable to report back to.
+     * Reporting is limited but exists.
+     * @throws IOException if the path is an
+     * existing directory, or the path exists but overwrite is false, or there is a
+     * failure in attempting to open for append with Ceph.
+     * @deprecated API only for 0.20-append
+     */
+     @Deprecated
+    public FSDataOutputStream createNonRecursive(Path path, FsPermission permission,
+                                                 boolean overwrite,
+                                                 int bufferSize, short replication, long blockSize,
+                                                 Progressable progress) throws IOException {
+
+        path = makeAbsolute(path);
+
+        Path parent = path.getParent();
+
+        if (parent != null) {
+            CephStat stat = new CephStat();
+            ceph.lstat(parent, stat); // handles FileNotFoundException case
+            if (stat.isFile())
+                throw new FileAlreadyExistsException(parent.toString());
+        }
+
+        return this.create(path, permission, overwrite,
+                bufferSize, replication, blockSize, progress);
+    }
+
+    /**
+     * Rename a file or directory.
+     * @param src The current path of the file/directory
+     * @param dst The new name for the path.
+     * @return true if the rename succeeded, false otherwise.
+     */
+    @Override
+    public boolean rename(Path src, Path dst) throws IOException {
+        boolean ret = false;
+        src = makeAbsolute(src);
+        dst = makeAbsolute(dst);
+
+        try {
+            ret = ceph.rename(src, dst);
+        } catch (FileNotFoundException e) {
+            throw e;
+        } catch (Exception e) {
+            return ret;
+        }
+
+        return ret;
+    }
+
+    @Deprecated
+    public boolean delete(Path path) throws IOException {
+        return delete(path, false);
+    }
+
+    @Override
+    public boolean delete(Path path, boolean recursive) throws IOException {
+        path = makeAbsolute(path);
+
+        /* path exists? */
+        FileStatus status;
+        try {
+            status = getFileStatus(path);
+        } catch (FileNotFoundException e) {
+            return false;
+        }
+
+        /* we're done if its a file */
+        if (status.isFile()) {
+            ceph.unlink(path);
+            return true;
+        }
+
+        /* get directory contents */
+        FileStatus[] dirlist = listStatus(path);
+        if (dirlist == null)
+            return false;
+
+        if (!recursive && dirlist.length > 0)
+            throw new IOException("Directory " + path.toString() + "is not empty.");
+
+        for (FileStatus fs : dirlist) {
+            if (!delete(fs.getPath(), recursive))
+                return false;
+        }
+
+        ceph.unlink(path);
+        return true;
+    }
+
+    @Override
+    public short getDefaultReplication() {
+        return ceph.getDefaultReplication();
+    }
+
+    @Override
+    public long getDefaultBlockSize() {
+        return getConf().getLong(
+                CephConfigKeys.CEPH_RGW_BLOCKSIZE_KEY,
+                CephConfigKeys.CEPH_RGW_BLOCKSIZE_DEFAULT);
+    }
+
+    @Override
+    public FsStatus getStatus(Path p) throws IOException {
+        CephStatVFS stat = new CephStatVFS();
+        ceph.statfs(p, stat);
+
+        FsStatus status = new FsStatus(stat.bsize * stat.blocks,
+                stat.bsize * (stat.blocks - stat.bavail),
+                stat.bsize * stat.bavail);
+        return status;
+    }
+}
+
+

--- a/src/main/java/org/apache/hadoop/fs/cephrgw/CephTalker.java
+++ b/src/main/java/org/apache/hadoop/fs/cephrgw/CephTalker.java
@@ -1,0 +1,176 @@
+// -*- mode:Java; tab-width:2; c-basic-offset:2; indent-tabs-mode:t -*- 
+
+/**
+ * Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ * <p>
+ * <p>
+ * Wraps a number of native function calls to communicate with the Ceph
+ * filesystem.
+ */
+package org.apache.hadoop.fs.cephrgw;
+
+import java.io.IOException;
+import java.net.URI;
+import java.io.FileNotFoundException;
+import java.util.LinkedList;
+import java.net.InetAddress;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.commons.logging.Log;
+import org.apache.commons.lang.StringUtils;
+
+import com.ceph.rgw.CephRgwAdapter;
+import com.ceph.rgw.CephStat;
+import com.ceph.rgw.CephStatVFS;
+import com.ceph.rgw.CephFileAlreadyExistsException;
+
+class CephTalker extends CephFsProto {
+
+    private CephRgwAdapter rgwAdapter;
+    private short defaultReplication;
+    private String bucket;
+    private long cephPos = 0;
+    private Log LOG;
+
+    public CephTalker(Configuration conf, Log log) {
+        rgwAdapter = null;
+        LOG = log;
+    }
+
+    private boolean isRootDir(Path path) {
+        if (null == path || path.isRoot()) {
+            return true;
+        }
+        return false;
+    }
+
+    private String pathString(Path path, boolean isRoot) {
+        if (isRoot) {
+            return bucket;
+        }
+        return path.toUri().getPath().substring(1);
+    }
+
+    void initialize(URI uri, Configuration conf) throws IOException {
+        bucket = uri.getAuthority();
+        String args = conf.get(CephConfigKeys.CEPH_RGW_ARGS_KEY, CephConfigKeys.CEPH_RGW_ARGS_DEFAULT);
+        rgwAdapter = new CephRgwAdapter(args);
+
+        String userId = conf.get(CephConfigKeys.CEPH_RGW_USERID_KEY, CephConfigKeys.CEPH_RGW_USERID_DEFAULT);
+
+        String accessKey = conf.get(CephConfigKeys.CEPH_RGW_ACCESS_KEY_KEY, CephConfigKeys.CEPH_RGW_ACCESS_KEY_DEFAULT);
+        String secretKey = conf.get(CephConfigKeys.CEPH_RGW_SECRET_KEY_KEY, CephConfigKeys.CEPH_RGW_SECRET_KEY_DEFAULT);
+
+        defaultReplication = (short) conf.getInt(CephConfigKeys.CEPH_REPLICATION_KEY,
+                CephConfigKeys.CEPH_REPLICATION_DEFAULT);
+
+        try {
+            rgwAdapter.mount(userId, accessKey, secretKey, uri.getAuthority());
+        } catch (NullPointerException ne) {
+            throw new IOException(String.format("mount %s with userId %s accessKey %s secretKey %s failed.",
+                    uri.getAuthority(), userId, accessKey, secretKey), ne);
+        }
+    }
+
+    long __open(Path path, int flags, int mode) throws IOException {
+        boolean isRoot = isRootDir(path);
+        return rgwAdapter.open(pathString(path, isRoot), isRoot, flags, mode);
+    }
+
+    long open(Path path, int flags, int mode) throws IOException {
+        return __open(path, flags, mode);
+    }
+
+    void lstat(Path path, CephStat stat) throws IOException {
+        boolean isRoot = isRootDir(path);
+        try {
+            rgwAdapter.lstat(pathString(path, isRoot), isRoot, stat);
+        } catch (FileNotFoundException e) {
+            throw new FileNotFoundException();
+        }
+    }
+
+    void statfs(Path path, CephStatVFS stat) throws IOException {
+        boolean isRoot = isRootDir(path);
+        try {
+            rgwAdapter.statfs(pathString(path, isRoot), isRoot, stat);
+        } catch (FileNotFoundException e) {
+            throw new FileNotFoundException();
+        }
+    }
+
+    void unlink(Path path) throws IOException {
+        boolean isRoot = isRootDir(path);
+        rgwAdapter.unlink(pathString(path, isRoot), isRoot);
+    }
+
+    boolean rename(Path from, Path to) throws IOException {
+        Path src = from.getParent();
+        Path dst = to.getParent();
+        boolean srcIsRoot = isRootDir(src);
+        boolean dstIsRoot = isRootDir(dst);
+        try {
+            int ret = rgwAdapter.rename(pathString(src, srcIsRoot), srcIsRoot, from.getName(),
+                    pathString(dst, dstIsRoot), dstIsRoot, to.getName());
+            if (ret == 0)
+                return true;
+        } catch (FileNotFoundException e) {
+            throw new FileNotFoundException();
+        }
+        return false;
+    }
+
+    int listdir(Path path, LinkedList<String> nameList, LinkedList<CephStat> statList) throws IOException {
+        boolean isRoot = isRootDir(path);
+        return rgwAdapter.listdir(pathString(path, isRoot), isRoot, nameList, statList);
+    }
+
+    boolean mkdirs(Path path, int mode) throws IOException {
+        Path parent = path.getParent();
+        boolean isRoot = isRootDir(parent);
+        return rgwAdapter.mkdirs(pathString(parent, isRoot), isRoot, path.getName(), mode);
+    }
+
+    void close(long fd) throws IOException {
+        rgwAdapter.close(fd);
+    }
+
+    void shutdown() throws IOException {
+        if (null != rgwAdapter)
+            rgwAdapter.unmount();
+        rgwAdapter = null;
+    }
+
+    short getDefaultReplication() {
+        return defaultReplication;
+    }
+
+    void setattr(Path path, CephStat stat, int mask) throws IOException {
+        boolean isRoot = isRootDir(path);
+        rgwAdapter.setattr(pathString(path, isRoot), isRoot, stat, mask);
+    }
+
+    void fsync(long fd) throws IOException {
+        rgwAdapter.fsync(fd, false);
+    }
+
+    int write(long fd, long offset, byte[] buf, long size) throws IOException {
+        return (int) rgwAdapter.write(fd, offset, buf, size);
+    }
+
+    int read(long fd, long offset, byte[] buf, long size) throws IOException {
+        return (int) rgwAdapter.read(fd, offset, buf, size);
+    }
+
+}


### PR DESCRIPTION
In the existing Hadoop S3a access Ceph solution, read and write requests are first sent to the object gateway, and then the radosgw daemon forwards the requests to the rados cluster. This patch add CephRgwFileSystem, it enables read and write requests to be directly sent to the rados cluster through the librgw, avoiding radosgw forwarding, shortening the I/O path, and improving performance.
HDFS CephRgwFileSystem encapsulates the read and write requests of Hadoop applications, invokes CephRgwAdapter, converts the requests to local librgw.so calls using libcephrgw_jni, and accesses the rados cluster. CephRgwFileSystem is stored in cephfs-hadoop repo, CephRgwAdapter and libcephrgw_jni are stored in ceph repo. Before compiling CephRgwFileSystem, install the cephrgw-java package corresponding to the CephRgwAdapter class.
CephRgwFileSystem  provides services externally using the cephrgw://bucket. If the bucket does not exist, it will be created. This patch supports HDFS read, write, ls, mkdir, delete, rename, and chmod. The current defect is that the rename directory and appending are not supported.

Fixes: https://tracker.ceph.com/issues/48513
Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>
Signed-off-by: Fengge Chen <chenfengge1@huawei.com>
Signed-off-by: luo rixin <luorixin@huawei.com>